### PR TITLE
Eliminate Cloned and update examples to support stable rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,47 +37,50 @@
 //!
 //! [sieve]: http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
 //!
-//! ```ignore
-//! # #![feature(collections, core, step_by)]
-//! use std::collections::{BitSet, BitVec};
-//! use std::iter;
+//! ```
+//! use bit_vec::BitVec;
 //!
 //! let max_prime = 10000;
 //!
-//! // Store the primes as a BitSet
+//! // Store the primes as a BitVec
 //! let primes = {
 //!     // Assume all numbers are prime to begin, and then we
 //!     // cross off non-primes progressively
-//!     let mut bv = BitVec::from_elem(max_prime, true);
+//!     let mut bv = BitVec::<u32>::from_elem(max_prime, true);
 //!
 //!     // Neither 0 nor 1 are prime
 //!     bv.set(0, false);
 //!     bv.set(1, false);
 //!
-//!     for i in iter::range_inclusive(2, (max_prime as f64).sqrt() as usize) {
+//!     for i in 2.. 1 + (max_prime as f64).sqrt() as usize {
 //!         // if i is a prime
 //!         if bv[i] {
 //!             // Mark all multiples of i as non-prime (any multiples below i * i
 //!             // will have been marked as non-prime previously)
-//!             for j in (i * i..max_prime).step_by(i) { bv.set(j, false) }
+//!             for j in i.. {
+//!                 if i * j >= max_prime {
+//!                     break;
+//!                 }
+//!                 bv.set(i * j, false)
+//!             }
 //!         }
 //!     }
-//!     BitSet::from_bit_vec(bv)
+//!     bv
 //! };
 //!
 //! // Simple primality tests below our max bound
 //! let print_primes = 20;
 //! print!("The primes below {} are: ", print_primes);
 //! for x in 0..print_primes {
-//!     if primes.contains(&x) {
+//!     if primes.get(x).unwrap_or(false) {
 //!         print!("{} ", x);
 //!     }
 //! }
 //! println!("");
 //!
-//! // We can manipulate the internal BitVec
-//! let num_primes = primes.get_ref().iter().filter(|x| *x).count();
+//! let num_primes = primes.iter().filter(|x| *x).count();
 //! println!("There are {} primes below {}", num_primes, max_prime);
+//! assert_eq!(num_primes, 1_229);
 //! ```
 use std::cmp::Ordering;
 use std::cmp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! [sieve]: http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
 //!
-//! ```
+//! ```ignore
 //! # #![feature(collections, core, step_by)]
 //! use std::collections::{BitSet, BitVec};
 //! use std::iter;
@@ -159,10 +159,9 @@ static FALSE: bool = false;
 /// # Examples
 ///
 /// ```
-/// # #![feature(collections)]
-/// use std::collections::BitVec;
+/// use bit_vec::BitVec;
 ///
-/// let mut bv = BitVec::from_elem(10, false);
+/// let mut bv = BitVec::<u32>::from_elem(10, false);
 ///
 /// // insert all primes less than 10
 /// bv.set(2, true);
@@ -288,9 +287,8 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
-    /// let mut bv = BitVec::new();
+    /// use bit_vec::BitVec;
+    /// let mut bv = BitVec::<u32>::new();
     /// ```
     pub fn new() -> Self {
         BitVec { storage: Vec::new(), nbits: 0 }
@@ -302,10 +300,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(10, false);
+    /// let mut bv = BitVec::<u32>::from_elem(10, false);
     /// assert_eq!(bv.len(), 10);
     /// for x in bv.iter() {
     ///     assert_eq!(x, false);
@@ -342,10 +339,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let bv = BitVec::from_bytes(&[0b10100000, 0b00010010]);
+    /// let bv = BitVec::<u32>::from_bytes(&[0b10100000, 0b00010010]);
     /// assert!(bv.eq_vec(&[true, false, true, false,
     ///                     false, false, false, false,
     ///                     false, false, false, true,
@@ -386,10 +382,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let bv = BitVec::from_fn(5, |i| { i % 2 == 0 });
+    /// let bv = BitVec::<u32>::from_fn(5, |i| { i % 2 == 0 });
     /// assert!(bv.eq_vec(&[true, false, true, false, true]));
     /// ```
     pub fn from_fn<F>(len: usize, mut f: F) -> Self
@@ -407,10 +402,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let bv = BitVec::from_bytes(&[0b01100000]);
+    /// let bv = BitVec::<u32>::from_bytes(&[0b01100000]);
     /// assert_eq!(bv.get(0), Some(false));
     /// assert_eq!(bv.get(1), Some(true));
     /// assert_eq!(bv.get(100), None);
@@ -439,10 +433,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(5, false);
+    /// let mut bv = BitVec::<u32>::from_elem(5, false);
     /// bv.set(3, true);
     /// assert_eq!(bv[3], true);
     /// ```
@@ -462,15 +455,14 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
     /// let before = 0b01100000;
     /// let after  = 0b11111111;
     ///
-    /// let mut bv = BitVec::from_bytes(&[before]);
+    /// let mut bv = BitVec::<u32>::from_bytes(&[before]);
     /// bv.set_all();
-    /// assert_eq!(bv, BitVec::from_bytes(&[after]));
+    /// assert_eq!(bv, BitVec::<u32>::from_bytes(&[after]));
     /// ```
     #[inline]
     pub fn set_all(&mut self) {
@@ -483,15 +475,14 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
     /// let before = 0b01100000;
     /// let after  = 0b10011111;
     ///
-    /// let mut bv = BitVec::from_bytes(&[before]);
+    /// let mut bv = BitVec::<u32>::from_bytes(&[before]);
     /// bv.negate();
-    /// assert_eq!(bv, BitVec::from_bytes(&[after]));
+    /// assert_eq!(bv, BitVec::<u32>::from_bytes(&[after]));
     /// ```
     #[inline]
     pub fn negate(&mut self) {
@@ -512,18 +503,17 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
     /// let a   = 0b01100100;
     /// let b   = 0b01011010;
     /// let res = 0b01111110;
     ///
-    /// let mut a = BitVec::from_bytes(&[a]);
-    /// let b = BitVec::from_bytes(&[b]);
+    /// let mut a = BitVec::<u32>::from_bytes(&[a]);
+    /// let b = BitVec::<u32>::from_bytes(&[b]);
     ///
     /// assert!(a.union(&b));
-    /// assert_eq!(a, BitVec::from_bytes(&[res]));
+    /// assert_eq!(a, BitVec::<u32>::from_bytes(&[res]));
     /// ```
     #[inline]
     pub fn union(&mut self, other: &Self) -> bool {
@@ -543,14 +533,13 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
     /// let a   = 0b01100100;
     /// let b   = 0b01011010;
     /// let res = 0b01000000;
     ///
-    /// let mut a = BitVec::from_bytes(&[a]);
+    /// let mut a = BitVec::<u32>::from_bytes(&[a]);
     /// let b = BitVec::from_bytes(&[b]);
     ///
     /// assert!(a.intersect(&b));
@@ -574,21 +563,20 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
     /// let a   = 0b01100100;
     /// let b   = 0b01011010;
     /// let a_b = 0b00100100; // a - b
     /// let b_a = 0b00011010; // b - a
     ///
-    /// let mut bva = BitVec::from_bytes(&[a]);
+    /// let mut bva = BitVec::<u32>::from_bytes(&[a]);
     /// let bvb = BitVec::from_bytes(&[b]);
     ///
     /// assert!(bva.difference(&bvb));
     /// assert_eq!(bva, BitVec::from_bytes(&[a_b]));
     ///
-    /// let bva = BitVec::from_bytes(&[a]);
+    /// let bva = BitVec::<u32>::from_bytes(&[a]);
     /// let mut bvb = BitVec::from_bytes(&[b]);
     ///
     /// assert!(bvb.difference(&bva));
@@ -604,10 +592,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(5, true);
+    /// let mut bv = BitVec::<u32>::from_elem(5, true);
     /// assert_eq!(bv.all(), true);
     ///
     /// bv.set(1, false);
@@ -629,10 +616,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let bv = BitVec::from_bytes(&[0b01110100, 0b10010010]);
+    /// let bv = BitVec::<u32>::from_bytes(&[0b01110100, 0b10010010]);
     /// assert_eq!(bv.iter().filter(|x| *x).count(), 7);
     /// ```
     #[inline]
@@ -647,7 +633,7 @@ impl<B: BitBlock> BitVec<B> {
     ///
     /// ```
     /// # #![feature(collections, bit_vec_append_split_off)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
     /// let mut a = BitVec::from_bytes(&[0b10000000]);
     /// let mut b = BitVec::from_bytes(&[0b01100001]);
@@ -691,7 +677,7 @@ impl<B: BitBlock> BitVec<B> {
     ///
     /// ```
     /// # #![feature(collections, bit_vec_append_split_off)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     /// let mut a = BitVec::new();
     /// a.push(true);
     /// a.push(false);
@@ -750,10 +736,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(10, false);
+    /// let mut bv = BitVec::<u32>::from_elem(10, false);
     /// assert_eq!(bv.none(), true);
     ///
     /// bv.set(3, true);
@@ -768,10 +753,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(10, false);
+    /// let mut bv = BitVec::<u32>::from_elem(10, false);
     /// assert_eq!(bv.any(), false);
     ///
     /// bv.set(3, true);
@@ -790,15 +774,14 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(3, true);
+    /// let mut bv = BitVec::<u32>::from_elem(3, true);
     /// bv.set(1, false);
     ///
     /// assert_eq!(bv.to_bytes(), [0b10100000]);
     ///
-    /// let mut bv = BitVec::from_elem(9, false);
+    /// let mut bv = BitVec::<u32>::from_elem(9, false);
     /// bv.set(2, true);
     /// bv.set(8, true);
     ///
@@ -839,10 +822,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let bv = BitVec::from_bytes(&[0b10100000]);
+    /// let bv = BitVec::<u32>::from_bytes(&[0b10100000]);
     ///
     /// assert!(bv.eq_vec(&[true, false, true, false,
     ///                     false, false, false, false]));
@@ -860,10 +842,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_bytes(&[0b01001011]);
+    /// let mut bv = BitVec::<u32>::from_bytes(&[0b01001011]);
     /// bv.truncate(2);
     /// assert!(bv.eq_vec(&[false, true]));
     /// ```
@@ -886,10 +867,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(3, false);
+    /// let mut bv = BitVec::<u32>::from_elem(3, false);
     /// bv.reserve(10);
     /// assert_eq!(bv.len(), 3);
     /// assert!(bv.capacity() >= 13);
@@ -916,10 +896,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_elem(3, false);
+    /// let mut bv = BitVec::<u32>::from_elem(3, false);
     /// bv.reserve(10);
     /// assert_eq!(bv.len(), 3);
     /// assert!(bv.capacity() >= 13);
@@ -938,10 +917,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::new();
+    /// let mut bv = BitVec::<u32>::new();
     /// bv.reserve(10);
     /// assert!(bv.capacity() >= 10);
     /// ```
@@ -959,10 +937,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_bytes(&[0b01001011]);
+    /// let mut bv = BitVec::<u32>::from_bytes(&[0b01001011]);
     /// bv.grow(2, true);
     /// assert_eq!(bv.len(), 10);
     /// assert_eq!(bv.to_bytes(), [0b01001011, 0b11000000]);
@@ -1011,10 +988,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::from_bytes(&[0b01001001]);
+    /// let mut bv = BitVec::<u32>::from_bytes(&[0b01001001]);
     /// assert_eq!(bv.pop(), Some(true));
     /// assert_eq!(bv.pop(), Some(false));
     /// assert_eq!(bv.len(), 6);
@@ -1041,10 +1017,9 @@ impl<B: BitBlock> BitVec<B> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// use std::collections::BitVec;
+    /// use bit_vec::BitVec;
     ///
-    /// let mut bv = BitVec::new();
+    /// let mut bv = BitVec::<u32>::new();
     /// bv.push(true);
     /// bv.push(false);
     /// assert!(bv.eq_vec(&[true, false]));


### PR DESCRIPTION
Eliminate Cloned to support stable rust.

This is a change to public API so it is technically a breaking change.