### PR TITLE
Rename `clear()` to `clear_all()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ static FALSE: bool = false;
 /// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 ///
 /// // reset bitvector to empty
-/// bv.clear();
+/// bv.clear_all();
 /// println!("{:?}", bv);
 /// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 /// ```
@@ -1065,8 +1065,14 @@ impl<B: BitBlock> BitVec<B> {
 
     /// Clears all bits in this vector.
     #[inline]
-    pub fn clear(&mut self) {
+    pub fn clear_all(&mut self) {
         for w in &mut self.storage { *w = B::zero(); }
+    }
+
+    /// Set the size to zero
+    #[inline]
+    pub fn clear(&mut self) {
+        self.storage.clear()
     }
 }
 
@@ -1722,7 +1728,7 @@ mod tests {
     fn test_small_clear() {
         let mut b = BitVec::from_elem(14, true);
         assert!(!b.none() && b.all());
-        b.clear();
+        b.clear_all();
         assert!(b.none() && !b.all());
     }
 
@@ -1730,7 +1736,7 @@ mod tests {
     fn test_big_clear() {
         let mut b = BitVec::from_elem(140, true);
         assert!(!b.none() && b.all());
-        b.clear();
+        b.clear_all();
         assert!(b.none() && !b.all());
     }
 


### PR DESCRIPTION
For consistency with both other containers, and `set_all()`.

This is breaking the API, by silently changing the meaning of `clear()`.
Can be painful for the users.

Fixes #16
