### PR TITLE
Implementing serde traits for BitVec behind feature flag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - rust: stable
     - rust: nightly
       env: FEATURES="--features nightly"
+    - rust: nightly
+      env: FEATURES="--features eders"
 script:
     - cargo build $FEATURES
     - cargo test $FEATURES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 
 [dev-dependencies]
 rand = "*"
+serde_json = "0.6"
 
 [features]
 nightly = []
+eders = ["serde"]
+
+[dependencies]
+serde = { version = "0.6", optional = true }


### PR DESCRIPTION
As part of my quest to make rust-bio serde-friendly (https://github.com/rust-bio/rust-bio/pull/33, https://github.com/rust-bio/rust-bio/pull/34, https://github.com/contain-rs/vec-map/pull/15, https://github.com/rust-bio/rust-bio/pull/36), I'm hoping to get serde support merged for BitSet and BitVec. The former will require the change in this PR.

Because of the associated type here:

```rust
pub struct BitVec<B=u32> {
...
```

serde_macros/serde_codegen can't work out how to create the serde trait impls, so I've done it manually. I've also enabled a serde-enabled TravisCI build and a couple of basic tests. If you're interested in supporting this use case but think this needs more work, please let me know!