### PR TITLE
Implement rustc_serialize Decodable and Encodable traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ readme = "README.md"
 [dev-dependencies]
 rand = "*"
 
+[dependencies]
+rustc-serialize = "^0.3.*"
+
 [features]
 nightly = []


### PR DESCRIPTION
Implement rustc_serialize Decodable and Encodable traits for BitVec and its iterators. Also implement a method for constructing BitVec from raw storage.
