### PR TITLE
Add feature-flag based support option for no_std + alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-vec"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Alexis Beingessner <a.beingessner@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A vector of bits"
@@ -14,4 +14,8 @@ readme = "README.md"
 rand = "0.3.15"
 
 [features]
+default = ["std"]
+
 nightly = []
+
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,19 +83,20 @@
 //! assert_eq!(num_primes, 1_229);
 //! ```
 
-#![cfg_attr(not(feature="std"), no_std)]
+#![no_std]
 #![cfg_attr(not(feature="std"), feature(alloc))]
-
-
 
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[cfg(all(test, feature = "nightly"))] extern crate test;
 #[cfg(all(test, feature = "nightly"))] extern crate rand;
+
 #[cfg(any(test, feature = "std"))]
 #[macro_use]
-extern crate std as core;
+extern crate std;
+#[cfg(feature="std")]
+use std::vec::Vec;
 
-#[cfg(not(any(feature="std", test)))]
+#[cfg(not(feature="std"))]
 #[macro_use]
 extern crate alloc;
 #[cfg(not(feature="std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,23 +83,37 @@
 //! assert_eq!(num_primes, 1_229);
 //! ```
 
+#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(feature="std"), feature(alloc))]
+
+
+
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[cfg(all(test, feature = "nightly"))] extern crate test;
 #[cfg(all(test, feature = "nightly"))] extern crate rand;
+#[cfg(any(test, feature = "std"))]
+#[macro_use]
+extern crate std as core;
 
-use std::cmp::Ordering;
-use std::cmp;
-use std::fmt;
-use std::hash;
-use std::iter::{Chain, Enumerate, Repeat, Skip, Take, repeat};
-use std::iter::FromIterator;
-use std::slice;
-use std::{u8, usize};
+#[cfg(not(any(feature="std", test)))]
+#[macro_use]
+extern crate alloc;
+#[cfg(not(feature="std"))]
+use alloc::Vec;
+
+use core::cmp::Ordering;
+use core::cmp;
+use core::fmt;
+use core::hash;
+use core::iter::{Chain, Enumerate, Repeat, Skip, Take, repeat};
+use core::iter::FromIterator;
+use core::slice;
+use core::{u8, usize};
 
 type MutBlocks<'a, B> = slice::IterMut<'a, B>;
 type MatchWords<'a, B> = Chain<Enumerate<Blocks<'a, B>>, Skip<Take<Enumerate<Repeat<B>>>>>;
 
-use std::ops::*;
+use core::ops::*;
 
 /// Abstracts over a pile of bits (basically unsigned primitives)
 pub trait BitBlock:
@@ -154,7 +168,7 @@ bit_block_impl!{
     (u16, 16),
     (u32, 32),
     (u64, 64),
-    (usize, std::mem::size_of::<usize>() * 8)
+    (usize, core::mem::size_of::<usize>() * 8)
 }
 
 
@@ -1318,6 +1332,7 @@ impl<'a, B: BitBlock> ExactSizeIterator for Blocks<'a, B> {}
 #[cfg(test)]
 mod tests {
     use super::{BitVec, Iter};
+    use std::vec::Vec;
 
     // This is stupid, but I want to differentiate from a "random" 32
     const U32_BITS: usize = 32;


### PR DESCRIPTION
This work is intended to allow bit-vec to operate in `no_std` environments which have access to `alloc`.  

Existing users should not have any expected changes in use. New users interested in `no_std` mode (for embedded or wasm work) may opt-in by disabling a new default cargo flag, "std".

I expect to be making a similar PR to contain-rs/bit-set . 

CC: @Gankro @bholley 