### PR TITLE
Serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-vec"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Alexis Beingessner <a.beingessner@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A vector of bits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 
 [dev-dependencies]
 rand = "0.3.15"
+serde_json = "1.0"
+
+[dependencies]
+serde = "1.0"
+serde_derive = "1.0"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,10 @@
 #[cfg(any(test, feature = "std"))]
 #[macro_use]
 extern crate std;
+
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(feature="std")]
 use std::vec::Vec;
 
@@ -211,6 +215,7 @@ static FALSE: bool = false;
 /// println!("{:?}", bv);
 /// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 /// ```
+#[derive(Serialize, Deserialize)]
 pub struct BitVec<B=u32> {
     /// Internal representation of the bit vector
     storage: Vec<B>,
@@ -1332,6 +1337,8 @@ impl<'a, B: BitBlock> ExactSizeIterator for Blocks<'a, B> {}
 
 #[cfg(test)]
 mod tests {
+    extern crate serde_json;
+    
     use super::{BitVec, Iter};
     use std::vec::Vec;
 
@@ -2130,6 +2137,20 @@ mod tests {
     fn iter() {
         let b = BitVec::with_capacity(10);
         let _a: Iter = b.iter();
+    }
+
+    #[test]
+    fn test_serialization() {
+        let bit_vec: BitVec = BitVec::new();
+        let serialized = serde_json::to_string(&bit_vec).unwrap();
+        let unserialized: BitVec = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(bit_vec, unserialized);
+        
+        let bools = vec![true, false, true, true];
+        let bit_vec: BitVec = bools.iter().map(|n| *n).collect();
+        let serialized = serde_json::to_string(&bit_vec).unwrap();
+        let unserialized = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(bit_vec, unserialized);
     }
 }
 


### PR DESCRIPTION
This PR adds support for serialization with [serde](https://docs.rs/serde/1.0.46/serde/). This is required to add serialization support to `BitSet` in the `bit_set` crate as mentioned [here](https://github.com/contain-rs/bit-set/issues/14).

I increased the version number so that `bit_set` can require version `0.6.0` since the changes to `BitSet` would not compile without `BitVec` implementing the `Serialize` and `Deserialize` traits.

The test checks if the content of the array stay the same after serializing it deserializing it again.