### PR TITLE
Fix no-std `Vec` import.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ use std::vec::Vec;
 #[macro_use]
 extern crate alloc;
 #[cfg(not(feature="std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use core::cmp::Ordering;
 use core::cmp;


### PR DESCRIPTION
It used to be aliased at `alloc::Vec`, but as of recent nightlies is found at
`alloc::vec::Vec`.