### PR TITLE
Fix compatibility with older rustcs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl BitVec<u32> {
         let nblocks = blocks_for_bits::<B>(nbits);
         let mut bit_vec = BitVec {
             storage: vec![if bit { !B::zero() } else { B::zero() }; nblocks],
-            nbits,
+            nbits: nbits,
         };
         bit_vec.fix_last_block();
         bit_vec


### PR DESCRIPTION
This single line change meant that older rustc versions couldn't compile the newest version of `bit-vec`. Is that really worth it? I want to keep the MSRV for yasna.rs to be 1.16.0. It would be unfortunate to force me to adopt newer versions.