### PR TITLE
Remove unneeded unstable feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,6 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc_prelude))]
 
 #[cfg(any(test, feature = "std"))]
 #[macro_use]


### PR DESCRIPTION
I think we don't need alloc_prelude since alloc is stablized.