### PR TITLE
Implement `get_mut` and `iter_mut` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,9 +541,9 @@ impl<B: BitBlock> BitVec<B> {
     /// use bit_vec::BitVec;
     ///
     /// let mut bv = BitVec::from_bytes(&[0b01100000]);
-    /// *(bv.get_mut(0).unrwap()) = true;
-    /// *(bv.get_mut(1).unrwap()) = false;
-    /// assert_eq!(bv.get_mut(100), None);
+    /// *(bv.get_mut(0).unwrap()) = true;
+    /// *(bv.get_mut(1).unwrap()) = false;
+    /// assert!(bv.get_mut(100).is_none());
     /// assert_eq!(bv, BitVec::from_bytes(&[0b10100000]));
     /// ```
     #[inline]
@@ -552,7 +552,9 @@ impl<B: BitBlock> BitVec<B> {
             MutBorrowedBit {
                 vec: Rc::new(RefCell::new(self)),
                 index,
-                value
+                #[cfg(debug_assertions)]
+                old_value: value,
+                new_value: value
             })
     }
 
@@ -1601,10 +1603,13 @@ pub struct Iter<'a, B: 'a = u32> {
     range: Range<usize>,
 }
 
+#[derive(Debug)]
 pub struct MutBorrowedBit<'a, B: BitBlock> {
     vec: Rc<RefCell<&'a mut BitVec<B>>>,
     index: usize,
-    value: bool
+    #[cfg(debug_assertions)]
+    old_value: bool,
+    new_value: bool
 }
 
 /// An iterator for `BitVec`.
@@ -1618,19 +1623,22 @@ impl <'a, B: BitBlock> Deref for MutBorrowedBit<'a, B> {
     type Target = bool;
 
     fn deref(&self) -> &Self::Target {
-        &self.value
+        &self.new_value
     }
 }
 
 impl <'a, B: BitBlock> DerefMut for MutBorrowedBit<'a, B> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
+        &mut self.new_value
     }
 }
 
 impl <'a, B: BitBlock> Drop for MutBorrowedBit<'a, B> {
     fn drop(&mut self) {
-        (*self.vec).borrow_mut().set(self.index, self.value)
+        let mut vec = (*self.vec).borrow_mut();
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(Some(self.old_value), vec.get(self.index), "Mutably-borrowed bit was modified externally!");
+        vec.set(self.index, self.new_value);
     }
 }
 
@@ -1659,7 +1667,9 @@ impl<'a, B: BitBlock> Iterator for IterMut<'a, B> {
         Some(MutBorrowedBit {
             vec: self.vec.clone(),
             index,
-            value
+            #[cfg(debug_assertions)]
+            old_value: value,
+            new_value: value
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1612,8 +1612,7 @@ pub struct MutBorrowedBit<'a, B: 'a + BitBlock> {
     new_value: bool
 }
 
-/// An iterator for `BitVec`.
-#[derive(Clone)]
+/// An iterator for mutable references to the bits in a `BitVec`.
 pub struct IterMut<'a, B: 'a + BitBlock = u32> {
     vec: Rc<RefCell<&'a mut BitVec<B>>>,
     range: Range<usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,29 @@ impl<B: BitBlock> BitVec<B> {
             .map(|&block| (block & (B::one() << b)) != B::zero())
     }
 
+    /// Retrieves a smart pointer to the value at index `i`, or `None` if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bit_vec::BitVec;
+    ///
+    /// let mut bv = BitVec::from_bytes(&[0b01100000]);
+    /// *(bv.get_mut(0).unrwap()) = true;
+    /// *(bv.get_mut(1).unrwap()) = false;
+    /// assert_eq!(bv.get_mut(100), None);
+    /// assert_eq!(bv, BitVec::from_bytes(&[0b10100000]));
+    /// ```
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<MutBorrowedBit<B>> {
+        self.get(index).map(move |value|
+            MutBorrowedBit {
+                vec: self,
+                index,
+                value
+            })
+    }
+
     /// Sets the value of a bit at an index `i`.
     ///
     /// # Panics
@@ -1546,6 +1569,32 @@ impl<B: BitBlock> cmp::Eq for BitVec<B> {}
 pub struct Iter<'a, B: 'a = u32> {
     bit_vec: &'a BitVec<B>,
     range: Range<usize>,
+}
+
+pub struct MutBorrowedBit<'a, B: BitBlock> {
+    vec: &'a mut BitVec<B>,
+    index: usize,
+    value: bool
+}
+
+impl <'a, B: BitBlock> Deref for MutBorrowedBit<'a, B> {
+    type Target = bool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl <'a, B: BitBlock> DerefMut for MutBorrowedBit<'a, B> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl <'a, B: BitBlock> Drop for MutBorrowedBit<'a, B> {
+    fn drop(&mut self) {
+        self.vec.set(self.index, self.value)
+    }
 }
 
 impl<'a, B: BitBlock> Iterator for Iter<'a, B> {
@@ -2636,5 +2685,17 @@ mod tests {
         a.append(&mut b);
         a.append(&mut c);
         assert_eq!(&[0xc0, 0x00, 0x00, 0x00, 0x3f, 0xc0][..], &*a.to_bytes());
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut a = BitVec::from_elem(3, false);
+        let mut a_bit_1 = a.get_mut(1).unwrap();
+        assert_eq!(false, *a_bit_1);
+        *a_bit_1 = true;
+        drop(a_bit_1);
+        assert!(a.eq_vec(&[
+            false, true, false
+        ]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@
 #[macro_use]
 extern crate std;
 #[cfg(feature = "std")]
+use std::rc::Rc;
+#[cfg(feature = "std")]
 use std::vec::Vec;
 
 #[cfg(feature = "serde")]
@@ -100,8 +102,11 @@ use serde::{Deserialize, Serialize};
 #[macro_use]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use core::cell::RefCell;
 use core::cmp;
 use core::cmp::Ordering;
 use core::fmt;
@@ -216,7 +221,7 @@ pub struct BitVec<B = u32> {
     /// Internal representation of the bit vector
     storage: Vec<B>,
     /// The number of valid bits in the internal representation
-    nbits: usize,
+    nbits: usize
 }
 
 // FIXME(Gankro): NopeNopeNopeNopeNope (wait for IndexGet to be a thing)
@@ -545,7 +550,7 @@ impl<B: BitBlock> BitVec<B> {
     pub fn get_mut(&mut self, index: usize) -> Option<MutBorrowedBit<B>> {
         self.get(index).map(move |value|
             MutBorrowedBit {
-                vec: self,
+                vec: Rc::new(RefCell::new(self)),
                 index,
                 value
             })
@@ -970,6 +975,31 @@ impl<B: BitBlock> BitVec<B> {
         Iter {
             bit_vec: self,
             range: 0..self.nbits,
+        }
+    }
+
+    /// Returns an iterator over mutable smart pointers to the elements of the vector in order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bit_vec::BitVec;
+    ///
+    /// let mut a = BitVec::from_elem(8, false);
+    /// a.iter_mut().enumerate().for_each(|(index, mut bit)| {
+    ///     *bit = if index % 2 == 1 { true } else { false };
+    /// });
+    /// assert!(a.eq_vec(&[
+    ///    false, true, false, true, false, true, false, true
+    /// ]));
+    /// ```
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<B> {
+        self.ensure_invariant();
+        let nbits = self.nbits;
+        IterMut {
+            vec: Rc::new(RefCell::new(self)),
+            range: 0..nbits
         }
     }
 
@@ -1572,9 +1602,16 @@ pub struct Iter<'a, B: 'a = u32> {
 }
 
 pub struct MutBorrowedBit<'a, B: BitBlock> {
-    vec: &'a mut BitVec<B>,
+    vec: Rc<RefCell<&'a mut BitVec<B>>>,
     index: usize,
     value: bool
+}
+
+/// An iterator for `BitVec`.
+#[derive(Clone)]
+pub struct IterMut<'a, B: 'a = u32> {
+    vec: Rc<RefCell<&'a mut BitVec<B>>>,
+    range: Range<usize>,
 }
 
 impl <'a, B: BitBlock> Deref for MutBorrowedBit<'a, B> {
@@ -1593,7 +1630,7 @@ impl <'a, B: BitBlock> DerefMut for MutBorrowedBit<'a, B> {
 
 impl <'a, B: BitBlock> Drop for MutBorrowedBit<'a, B> {
     fn drop(&mut self) {
-        self.vec.set(self.index, self.value)
+        (*self.vec).borrow_mut().set(self.index, self.value)
     }
 }
 
@@ -1605,6 +1642,25 @@ impl<'a, B: BitBlock> Iterator for Iter<'a, B> {
         // NB: indexing is slow for extern crates when it has to go through &TRUE or &FALSE
         // variables.  get is more direct, and unwrap is fine since we're sure of the range.
         self.range.next().map(|i| self.bit_vec.get(i).unwrap())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<'a, B: BitBlock> Iterator for IterMut<'a, B> {
+    type Item = MutBorrowedBit<'a, B>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.range.next()?;
+        let value = (*self.vec).borrow().get(index)?;
+        Some(MutBorrowedBit {
+            vec: self.vec.clone(),
+            index,
+            value
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -2696,6 +2752,16 @@ mod tests {
         drop(a_bit_1);
         assert!(a.eq_vec(&[
             false, true, false
+        ]));
+    }
+    #[test]
+    fn test_iter_mut() {
+        let mut a = BitVec::from_elem(8, false);
+        a.iter_mut().enumerate().for_each(|(index, mut bit)| {
+            *bit = if index % 2 == 1 { true } else { false };
+        });
+        assert!(a.eq_vec(&[
+            false, true, false, true, false, true, false, true
         ]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1604,7 +1604,7 @@ pub struct Iter<'a, B: 'a = u32> {
 }
 
 #[derive(Debug)]
-pub struct MutBorrowedBit<'a, B: BitBlock> {
+pub struct MutBorrowedBit<'a, B: 'a + BitBlock> {
     vec: Rc<RefCell<&'a mut BitVec<B>>>,
     index: usize,
     #[cfg(debug_assertions)]
@@ -1614,9 +1614,23 @@ pub struct MutBorrowedBit<'a, B: BitBlock> {
 
 /// An iterator for `BitVec`.
 #[derive(Clone)]
-pub struct IterMut<'a, B: 'a = u32> {
+pub struct IterMut<'a, B: 'a + BitBlock = u32> {
     vec: Rc<RefCell<&'a mut BitVec<B>>>,
     range: Range<usize>,
+}
+
+impl <'a, B: 'a + BitBlock> IterMut<'a, B> {
+    fn get(&mut self, index: Option<usize>) -> Option<MutBorrowedBit<'a, B>> {
+        let index = index?;
+        let value = (*self.vec).borrow().get(index)?;
+        Some(MutBorrowedBit {
+            vec: self.vec.clone(),
+            index,
+            #[cfg(debug_assertions)]
+            old_value: value,
+            new_value: value
+        })
+    }
 }
 
 impl <'a, B: BitBlock> Deref for MutBorrowedBit<'a, B> {
@@ -1662,15 +1676,8 @@ impl<'a, B: BitBlock> Iterator for IterMut<'a, B> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let index = self.range.next()?;
-        let value = (*self.vec).borrow().get(index)?;
-        Some(MutBorrowedBit {
-            vec: self.vec.clone(),
-            index,
-            #[cfg(debug_assertions)]
-            old_value: value,
-            new_value: value
-        })
+        let index = self.range.next();
+        self.get(index)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1685,7 +1692,17 @@ impl<'a, B: BitBlock> DoubleEndedIterator for Iter<'a, B> {
     }
 }
 
+impl<'a, B: BitBlock> DoubleEndedIterator for IterMut<'a, B> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let index = self.range.next_back();
+        self.get(index)
+    }
+}
+
 impl<'a, B: BitBlock> ExactSizeIterator for Iter<'a, B> {}
+
+impl<'a, B: BitBlock> ExactSizeIterator for IterMut<'a, B> {}
 
 impl<'a, B: BitBlock> IntoIterator for &'a BitVec<B> {
     type Item = bool;


### PR DESCRIPTION
Implements `get_mut(&mut self, index: usize)` and `iter_mut(&mut self)` using a smart-pointer struct `MutBorrowedBit` that holds an `Rc<RefCell<&mut BitVec<_>>>` and the index, and writes the value back when dropped. The use of the `Rc<RefCell<_>>` allows mutable references to different bits in the same vector to coexist (necessary for `iter_mut` since all the `MutBorrowedBit` instances have the same lifetime as the `&mut self`).