### PR TITLE
Implement the Debug trait for BitVec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@ extern crate std;
 #[cfg(feature = "std")]
 use std::rc::Rc;
 #[cfg(feature = "std")]
+use std::string::String;
+#[cfg(feature = "std")]
 use std::vec::Vec;
 
 #[cfg(feature = "serde")]
@@ -111,6 +113,8 @@ use nanoserde::{DeBin, DeJson, DeRon, SerBin, SerJson, SerRon};
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::rc::Rc;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
@@ -1708,9 +1712,8 @@ impl<B: BitBlock> fmt::Display for BitVec<B> {
 impl<B: BitBlock> fmt::Debug for BitVec<B> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.ensure_invariant();
-        let mut storage = std::string::String::new();
-        let mut iter = self.iter().enumerate();
-        while let Some((i, bit)) = iter.next() {
+        let mut storage = String::with_capacity(self.len() + self.len() / B::bits());
+        for (i, bit) in self.iter().enumerate() {
             if i != 0 && i % B::bits() == 0 {
                 storage.push(' ');
             }
@@ -1966,6 +1969,13 @@ mod tests {
         assert_eq!(
             format!("{:?}", BitVec::from_elem(33, true)),
             "BitVec { storage: \"11111111111111111111111111111111 1\", nbits: 33 }"
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                BitVec::from_bytes(&[0b111, 0b000, 0b1110, 0b0001, 0b11111111, 0b00000000])
+            ),
+            "BitVec { storage: \"00000111000000000000111000000001 1111111100000000\", nbits: 48 }"
         )
     }
 


### PR DESCRIPTION
```rs
fn main() {
    let bits = BitVec::from_bytes(&[0, 0, 0, 0, 1]);
    dbg!(bits);
}
```
```
[examples/basic.rs:6:5] bits = BitVec {
    storage: "00000000000000000000000000000000 00000001",
    nbits: 40,
}
```
