### PR TITLE
Added `nth` to `BitVec::Iter` so that `.skip(n)` gets optimized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1937,6 +1937,10 @@ impl<'a, B: BitBlock> Iterator for Iter<'a, B> {
         self.range.next().map(|i| self.bit_vec.get(i).unwrap())
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.range.nth(n).and_then(|i|self.bit_vec.get(i))
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.range.size_hint()
     }


### PR DESCRIPTION
Fixes #122 